### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,5 +1,8 @@
 name: Node.js CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/sh-dinho/chat-application/security/code-scanning/2](https://github.com/sh-dinho/chat-application/security/code-scanning/2)

In general, the fix is to explicitly set the `permissions` for the `GITHUB_TOKEN` either at the workflow root (applies to all jobs) or at the job level, reducing them to the minimum required. For this Node.js CI workflow, all steps are read-only with respect to the repository, so `contents: read` is sufficient.

The best minimal change without altering functionality is to add a `permissions` block at the top level of `.github/workflows/node.js.yml` (alongside `name` and `on`), specifying `contents: read`. This will apply to the `build` job and any future jobs that don’t override permissions. Concretely, insert:

```yaml
permissions:
  contents: read
```

after the `name: Node.js CI` line and before the `on:` block. No additional methods, imports, or definitions are needed, and no existing lines need to be modified other than shifting line numbers.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
